### PR TITLE
Fixed incorrect version and assembly name in app.manifest.

### DIFF
--- a/Romzetron.Avalonia.Example/app.manifest
+++ b/Romzetron.Avalonia.Example/app.manifest
@@ -3,7 +3,7 @@
     <!-- This manifest is used on Windows only.
          Don't remove it as it might cause problems with window transparency and embeded controls.
          For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-    <assemblyIdentity version="11.2.0" name="AvaloniaTest.Desktop"/>
+    <assemblyIdentity version="11.2.1.0" name="Romzetron.Avalonia.Example"/>
 
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>


### PR DESCRIPTION
I do most of my developing on MacOS, and it's been a while since I built the project on Windows. The version and assembly name value in app.manifest were not correct, which is required to build on Windows. I was able to build again on Windows 10 after doing a Clean and Rebuild.